### PR TITLE
Remove unused dependencies

### DIFF
--- a/1.6.6.myrest-servlet2-application/pom.xml
+++ b/1.6.6.myrest-servlet2-application/pom.xml
@@ -35,6 +35,44 @@
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
             <version>2.22.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2</groupId>
+                    <artifactId>hk2-locator</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2</groupId>
+                    <artifactId>hk2-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2</groupId>
+                    <artifactId>hk2-utils</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2</groupId>
+                    <artifactId>osgi-resource-locator</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>aopalliance-repackaged</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
@feuyeux Hi, I am a user of project **_com.example:myrest-servlet2-application:1.0-SNAPSHOT_**. I found that its pom file introduced **_19_** dependencies. However, among them, **_14_** libraries (**_73%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_com.example:myrest-servlet2-application:1.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.glassfish.jersey.core:jersey-client:jar:2.22.1:compile
org.glassfish.hk2:hk2-api:jar:2.4.0-b31:compile
org.glassfish.hk2:hk2-utils:jar:2.4.0-b31:compile
org.glassfish.jersey.media:jersey-media-jaxb:jar:2.22.1:compile
org.glassfish.hk2:osgi-resource-locator:jar:1.0.1:compile
org.glassfish.hk2.external:aopalliance-repackaged:jar:2.4.0-b31:compile
org.glassfish.hk2.external:javax.inject:jar:2.4.0-b31:compile
org.glassfish.jersey.core:jersey-common:jar:2.22.1:compile
org.glassfish.jersey.core:jersey-server:jar:2.22.1:compile
javax.validation:validation-api:jar:1.1.0.Final:compile
org.glassfish.hk2:hk2-locator:jar:2.4.0-b31:compile
org.glassfish.jersey.bundles.repackaged:jersey-guava:jar:2.22.1:compile
org.javassist:javassist:jar:3.18.1-GA:compile
javax.annotation:javax.annotation-api:jar:1.2:compile
</code></pre>