### PR TITLE
Could my.restful:my-first-webapp:1.0-SNAPSHOT drop off redundant dependencies? 

### DIFF
--- a/1.5.my-first-webapp/pom.xml
+++ b/1.5.my-first-webapp/pom.xml
@@ -55,6 +55,28 @@
             <artifactId>jersey-container-servlet-core</artifactId>
             <!-- use the following artifactId if you don't need servlet 2.x compatibility -->
             <!-- artifactId>jersey-container-servlet</artifactId -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2</groupId>
+                    <artifactId>osgi-resource-locator</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- uncomment this to get JSON support
         <dependency>


### PR DESCRIPTION
Hi! I found the pom file of project **_my.restful:my-first-webapp:1.0-SNAPSHOT_** introduced **_13_** dependencies. However, among them, **_8_** libraries (**_61%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.glassfish.jersey.core:jersey-common:jar:2.27:compile
org.glassfish.jersey.core:jersey-server:jar:2.27:compile
org.glassfish.jersey.core:jersey-client:jar:2.27:compile
org.glassfish.jersey.media:jersey-media-jaxb:jar:2.27:compile
org.glassfish.hk2:osgi-resource-locator:jar:1.0.1:compile
javax.validation:validation-api:jar:1.1.0.Final:compile
org.glassfish.hk2.external:javax.inject:jar:2.5.0-b42:compile
javax.annotation:javax.annotation-api:jar:1.2:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_org.glassfish.jersey.media:jersey-media-jaxb:jar:2.27:compile_** incorporates a high-level vulnerability SNYK-JAVA-ORGGLASSFISHJERSEYMEDIA-595972. As such, I suggest a refactoring operation for **_my.restful:my-first-webapp:1.0-SNAPSHOT_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_my.restful:my-first-webapp:1.0-SNAPSHOT_**’s maven tests.

Best regards