### PR TITLE
Could com.example:boot.etcd:jar:0.0.1-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/7.3.3.boot.etcd/pom.xml
+++ b/7.3.3.boot.etcd/pom.xml
@@ -39,6 +39,12 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-commons</artifactId>
             <version>1.1.0.RELEASE</version>
+            <exclusions>
+                <exclusion>
+                  <artifactId>spring-security-crypto</artifactId>
+                  <groupId>org.springframework.security</groupId>
+                </exclusion>
+             </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-cluster-etcd -->
         <dependency>
@@ -49,6 +55,10 @@
                 <exclusion>
                     <groupId>com.netflix.ribbon</groupId>
                     <artifactId>ribbon-httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jul-to-slf4j</artifactId>
+                    <groupId>org.slf4j</groupId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -62,12 +72,62 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-tomcat</artifactId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>asm-commons</artifactId>
+                    <groupId>org.ow2.asm</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-boot-starter</artifactId>
+                    <groupId>org.springframework.boot</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>asm</artifactId>
+                    <groupId>org.ow2.asm</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>asm-util</artifactId>
+                    <groupId>org.ow2.asm</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jakarta.activation-api</artifactId>
+                    <groupId>jakarta.activation</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                    <groupId>jakarta.xml.bind</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>asm-analysis</artifactId>
+                    <groupId>org.ow2.asm</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>hk2</artifactId>
+                    <groupId>org.glassfish.hk2</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jetty</artifactId>
             <version>${spring-boot.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>asm-commons</artifactId>
+                    <groupId>org.ow2.asm</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>asm</artifactId>
+                    <groupId>org.ow2.asm</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>asm-analysis</artifactId>
+                    <groupId>org.ow2.asm</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jetty-util-ajax</artifactId>
+                    <groupId>org.eclipse.jetty</groupId>
+                </exclusion>
+             </exclusions>
         </dependency>
 
         <dependency>
@@ -75,6 +135,20 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
             <version>${spring-boot.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>asm</artifactId>
+                    <groupId>org.ow2.asm</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                    <groupId>jakarta.xml.bind</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-boot-starter</artifactId>
+                    <groupId>org.springframework.boot</groupId>
+                </exclusion>
+             </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
![11](https://user-images.githubusercontent.com/126549527/223678694-664dfb61-7324-4a2c-8a01-226bc88f5f40.png)
![22](https://user-images.githubusercontent.com/126549527/223678702-1d26cca2-bc59-4f5f-8ad9-21788e01b5ac.png)
![33](https://user-images.githubusercontent.com/126549527/223678719-99c790f4-2489-4bdb-975b-b892fd92742b.png)
![44](https://user-images.githubusercontent.com/126549527/223678735-ebf0a59b-0ce9-40ff-9732-47cbbfa21a35.png)
![55](https://user-images.githubusercontent.com/126549527/223678749-4f368d6c-6304-4171-a5f0-aa1452e7d748.png)
![66](https://user-images.githubusercontent.com/126549527/223678764-bce4fdb6-5751-4d03-bb57-25e8e360dfe1.png)
![77](https://user-images.githubusercontent.com/126549527/223679283-be84668f-2b8c-4f51-b9f0-559e42021896.png)

Hi, I found that **_com.example:boot.etcd:jar:0.0.1-SNAPSHOT_**’s pom file introduced **_127_** dependencies. However, among them, **_10_** libraries (**_8%_** have not been used by your project), the redundant dependencies are listed below. 

More seriously, **_1_** redundant dependencies contain security vulnerabilities (vulnerable libraries). 

**_5_**  redundant libraries have not been maintained by developers for more than **_3_** years（outdated dependencies）. 

**_1_** redundant library has introduced an open source license conflict **_org.glassfish.hk2:hk2:2.6.1_**.The dependent open source license is **_EPL 2.0_**(**_EPL 2.0_** cannot be used by the project with license **_Apache License, Version 2.0_**).

Reduce these unused dependencies can help prevent introducing bugs/vulnerabilities from dependencies with security vulnerabilities, outdated and open source license conflict. Meanwhile, it can minimize the project size. To safely remove redundant dependencies, I constructed a complete call graph (resolved most of Java reflection and dynamic binding) , and validated that they have not been used by the client code.
 
This PR **_com.example:boot.etcd:jar:0.0.1-SNAPSHOT_** for removing the redundant dependencies have passed the tests.

Best regards

## Redundant dependencies
#### Redundant indirect dependencies:
         jakarta.activation:jakarta.activation-api:1.2.2:compile [45 KB]
         jakarta.xml.bind:jakarta.xml.bind-api:2.3.3:compile [112 KB]
         org.springframework.security:spring-security-crypto:5.6.2:compile [79 KB]
         org.ow2.asm:asm-analysis:7.1:compile [32 KB]
         org.eclipse.jetty:jetty-util-ajax:9.4.45.v20220203:compile [65 KB]
         org.ow2.asm:asm-commons:9.2:compile [70 KB]
         org.ow2.asm:asm:9.2:compile [119 KB]
         org.slf4j:jul-to-slf4j:1.7.36:compile [4 KB]
         org.glassfish.hk2:hk2:2.6.1:compile [15 KB]
         org.ow2.asm:asm-util:7.1:compile [79 KB]  
        

## Vulnerable libraries
org.springframework.security:spring-security-crypto:5.6.2 ([CVE-2022-22976](https://www.cve.org/CVERecord?id=CVE-2022-22976)）

## Outdated dependencies
org.ow2.asm:asm-util:7.1 (**_1466_** days without maintenance) 
org.glassfish.hk2:hk2:2.6.1 (**_1292_** days without maintenance)
jakarta.activation:jakarta.activation-api:1.2.2(**_1111_** days without maintenance)
jakarta.xml.bind:jakarta.xml.bind-api:2.3.3 (**_1136_** days without maintenance)
org.ow2.asm:asm-analysis:7.1(**_1466_** days without maintenance)


## Open source license conflict dependencies
org.glassfish.hk2:hk2:2.6.1
